### PR TITLE
change to using async pipe part one

### DIFF
--- a/src/app/containers/app.component.ts
+++ b/src/app/containers/app.component.ts
@@ -3,8 +3,6 @@ import { Store } from '@ngrx/store';
 import { id } from '../utils/id';
 import { people } from '../reducers/people';
 import { ADD_PERSON, REMOVE_PERSON, ADD_GUEST, REMOVE_GUEST, TOGGLE_ATTENDING } from '../actions/actions';
-// import { PersonList } from './person-list';
-// import { PersonInput } from './person-input';
 
 @Component({
   selector: 'app-root',
@@ -12,23 +10,21 @@ import { ADD_PERSON, REMOVE_PERSON, ADD_GUEST, REMOVE_GUEST, TOGGLE_ATTENDING } 
   styleUrls: ['./app.component.css']
 })
 export class AppComponent {
-  public people;
-  private subscription;
+  public people$;
 
-  constructor(  private _store: Store<any>) {
-    /* 
-      demonstrating use without the async pipe,
-      we will explore the async pipe in the next lesson
-    */
-    this.subscription = this._store
-      .select('people')
-      .subscribe(people => {
-        this.people = people;
-      });
+  constructor(private _store: Store<any>) {
+      /*
+        Observable of people, utilzing the async pipe
+        in our templates this will be subscribed to, with
+        new values being dispayed in our template.
+        Unsubscribe wil be called automatically when component
+        is disposed.
+      */
+      this.people$ = _store.select('people');
   }
   // all state-changing actions get dispatched to and handled by reducers
   addPerson(name) {
-    this._store.dispatch({ type: ADD_PERSON, payload: { id: id(), name: name }} );
+    this._store.dispatch({ type: ADD_PERSON, payload: { id: id(), name: name } });
   }
 
   addGuest(id) {
@@ -44,14 +40,8 @@ export class AppComponent {
   }
 
   toggleAttending(id) {
-    this._store.dispatch({ type: TOGGLE_ATTENDING, payload: id })
+    this._store.dispatch({ type: TOGGLE_ATTENDING, payload: id });
   }
-  /*
-    if you do not use async pipe and create manual subscriptions
-    always remember to unsubscribe in ngOnDestroy
-  */
-  ngOnDestroy() {
-    this.subscription.unsubscribe();
-  }
+  // ngOnDestroy to unsubscribe is no longer necessary
 
 }


### PR DESCRIPTION
> The AsyncPipe is a unique, stateful pipe in Angular 2 meant for handling both Observables and Promises. When using the AsyncPipe in a template expression with Observables, the supplied Observable is subscribed to, with emitted values being displayed within your view. This pipe also handles unsubscribing to the supplied observable, saving you the mental overhead of manually cleaning up subscriptions in ngOnDestroy. In a Store application, you will find yourself leaning on the AsyncPipe heavily in nearly all of your component views. For a more detailed explanation of exactly how the AsyncPipe works, check out my article Understand and Utilize the AsyncPipe in Angular 2 or free egghead.io video Using the Async Pipe in Angular 2.
> 
> Utilizing the AsyncPipe in our templates is easy. You can pipe any Observable (or promise) through async and a subscription will be created, updating the template value on source emission. Because we are using the AsyncPipe, we can also remove the manual subscription from the component constructor and unsubscribe from the ngOnDestroy lifecycle hook. This is now handled for us behind the scenes.